### PR TITLE
fix: use a modern base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM debian:buster-slim
 
 # Make sure dependencies are installed
 RUN apt-get update && apt-get install -y python3 python3-pip


### PR DESCRIPTION
The lint job in dunlop's GHA seems to be broken, wanted to see if upgrading the base image would help

* update base image to modern LTS debian based distro
* use the slim variant